### PR TITLE
Fixed error "Need even number of args" from Makefile.PL script.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -29,10 +29,10 @@ WriteMakefile(
         ?    ## Add these new keywords supported since 5.005
           (
             ABSTRACT_FROM => 'lib/Archive/Tar/Wrapper.pm',
-            AUTHOR        => (
+            AUTHOR        => [
                 'Mike Schilli <cpan@perlmeister.com>',
                 'Alceu Rodrigues de Freitas Junior <arfreitas@cpan.org>'
-            ),
+            ],
           )
         : ()
     ),


### PR DESCRIPTION
Hi @glasswalk3r 

Please review the PR.
Proposed fix for the error "WriteMakefile: Need even number of args at Makefile.PL line 15."

Many Thanks.
Best Regards,
Mohammad S Anwar