### PR TITLE
fix resources in META files

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -51,13 +51,16 @@ my %WriteMakefileArgs = (
 
 if ( $ExtUtils::MakeMaker::VERSION >= 6.50 ) {
     $WriteMakefileArgs{META_MERGE} = {
+        'meta-spec' => { version => 2 },
         'resources' => {
-            'type' => 'git',
-            'url'  => 'https://github.com/glasswalk3r/archive-tar-wrapper-perl',
-            'repository' =>
-              'https://github.com/glasswalk3r/archive-tar-wrapper-perl.git',
-            'bugtracker' =>
-              'https://github.com/glasswalk3r/archive-tar-wrapper-perl/issues'
+            'bugtracker' => {
+                'web' => 'https://github.com/glasswalk3r/archive-tar-wrapper-perl/issues',
+            },
+            'repository' => {
+                'type' => 'git',
+                'url' => 'https://github.com/glasswalk3r/archive-tar-wrapper-perl.git',
+                'web' => 'https://github.com/glasswalk3r/archive-tar-wrapper-perl',
+            },
         },
     };
 }


### PR DESCRIPTION
Currently Archive-Tar-Wrapper-0.29 contains (maybe unexpected) X_git or X_url fields in META.json
https://metacpan.org/source/ARFREITAS/Archive-Tar-Wrapper-0.29/META.json#L51-60

This PR fixes this.