### PR TITLE
make it work on Solaris

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,10 +3,6 @@ use strict;
 use ExtUtils::MakeMaker;
 use File::Which;
 
-if ( $^O eq 'solaris' ) {
-    die "OS unsupported\n";
-}
-
 if ( $^O eq 'MSWin32' ) {
     require Win32;
     my $product_info = Win32::GetOSDisplayName();


### PR DESCRIPTION
Solaris's `tar` is even weirder and old-fashioned than OpenBSD's, but this should make it work. I've only been able to test it on Illumos though, not on real Solaris.